### PR TITLE
Server restructure

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# This is the top-most .editorconfig file; do not search in parent directories.
+root = true
+
+[*]
+end_of_line = LF
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{rb,ru,ex,exs}]
+indent_size = 2
+
+[{Gemfile}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,21 @@
-dist/
+# The compiled JavaScript
+/static/dist/
+
+# Editors
+*~
+tags
+tags.*
+.idea/
+.vscode/
+*.sw[op]
+
+# Python
+*.py[cod]
+__pycache__/
+.venv/
+
+# Node
+node_modules/
+
+# Ruby
+/.bundle

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+    "endOfLine": "lf",
+    "semi": true,
+    "singleQuote": true,
+    "tabWidth": 4,
+    "trailingComma": "es5"
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.PHONY: clean start
+
+help:
+	@echo "clean - remove junk files"
+
+clean:
+	find . -name '*.pyc' -exec rm -f {} +
+	find . -name '*.pyo' -exec rm -f {} +
+	find . -name '*~' -exec rm -f {} +
+	find . -name '__pycache__' -exec rm -rf {} +
+
+start:
+	python app.py
+	tsc --watch

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: clean start
+.PHONY: clean start check format
 
 help:
 	@echo "clean - remove junk files"
+	@echo "start - start the dev servers"
+	@echo "flake8 - check the python code for PEP8"
+	@echo "prettier - check with prettier and write"
 
 clean:
 	find . -name '*.pyc' -exec rm -f {} +
@@ -12,3 +15,9 @@ clean:
 start:
 	python app.py
 	tsc --watch
+
+flake8:
+	flake8 .
+
+prettier:
+	prettier ./**/*.{js,css,json,sass} --check

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 ## Installation and usage
 - Requires typescript 3.* and a newish python3
 - `pip install -r requirements` to install server dependencies
-- `python -m 'http.server'` to serve index.html (flask should do this instead)
-- `python app.py` to start the flask server
-- run `tsc --watch` to start the typescript compiler
+- `make start` to run the servers (it will start `python app.py` and `tsc --watch`)

--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 import uuid
-from flask import Flask, request
+from flask import Flask, request, render_template
 from flask_socketio import SocketIO, emit
 
 
@@ -11,9 +11,18 @@ game_state = {
     'entities': {}
 }
 
+
+@app.route('/')
+def homepage():
+    """Render the index.html file that contains the frontend application."""
+    return render_template('index.html')
+
+
+
 @socketio.on('message')
 def handle_message(message):
     print('received message: ' + message)
+
 
 @socketio.on('action')
 def handle_action(message):
@@ -36,21 +45,20 @@ def handle_action(message):
 def handle_connect():
     game_state['entities'][request.sid] = [0,0]
     broadcast_state()
-    
 
 
 @socketio.on('disconnect')
 def handle_disconnect():
     del game_state['entities'][request.sid]
     broadcast_state
-    
+
 
 def broadcast_state():
     print(game_state)
     socketio.emit('world', game_state)
-    
+
 
 if __name__ == '__main__':
     print("running")
-    socketio.run(app)
+    socketio.run(app, use_reloader=True)
 

--- a/app.py
+++ b/app.py
@@ -18,7 +18,6 @@ def homepage():
     return render_template('index.html')
 
 
-
 @socketio.on('message')
 def handle_message(message):
     print('received message: ' + message)

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,10 +2,10 @@
 <html>
     <meta charset="utf-8"/>
     <head>
-        <title>Experience Points</title>
+        <title>XExperience Points</title>
         <script src="//cdnjs.cloudflare.com/ajax/libs/socket.io/2.2.0/socket.io.js" integrity="sha256-yr4fRk/GU1ehYJPAs8P4JlTgu0Hdsp4ZKrx8bDEDC3I=" crossorigin="anonymous"></script>
-        <script src="dist/server.js" type="module"></script>
-        <script src="dist/app.js" type="module"></script>
+        <script src="/static/dist/server.js" type="module"></script>
+        <script src="/static/dist/app.js" type="module"></script>
         <style>
             * { padding: 0; margin: 0; }
             canvas { background: #eee; display: block; margin: 0 auto; }
@@ -15,4 +15,4 @@
         <canvas id="canvas" width="480" height="320"></canvas>
     </body>
 </html>
- 
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,7 +2,7 @@
 <html>
     <meta charset="utf-8"/>
     <head>
-        <title>XExperience Points</title>
+        <title>Experience Points</title>
         <script src="//cdnjs.cloudflare.com/ajax/libs/socket.io/2.2.0/socket.io.js" integrity="sha256-yr4fRk/GU1ehYJPAs8P4JlTgu0Hdsp4ZKrx8bDEDC3I=" crossorigin="anonymous"></script>
         <script src="/static/dist/server.js" type="module"></script>
         <script src="/static/dist/app.js" type="module"></script>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "sourceMap": true,
     "target": "es6",
     "module": "es6",
-    "outDir": "./dist/"
+    "outDir": "./static/dist/"
   },
   "include": [
         "./client/**/*"


### PR DESCRIPTION
Proposed changes:

- serve `index.html` from Flask
- serve JavaScript from Flask's `static` directory
- moved server starting to `Makefile` (run `make start` to start the app)
- added files for code linting to make editor happy (`.editorconfig` and `.prettierrc`)
- expanded `.gitignore` rules for Python and editors