### PR TITLE
Add gameplay loop in background thread

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,3 @@
-import time
-from threading import Thread
 from flask import Flask, request, render_template
 from flask_socketio import SocketIO, emit
 import server.ticker as ticker
@@ -7,7 +5,7 @@ import server.ticker as ticker
 
 app = Flask(__name__)
 app.config['SECRET_KEY'] = 'notarealsecret'
-socketio = SocketIO(app, async_mode='gevent')
+socketio = SocketIO(app)
 
 
 @app.route('/')
@@ -44,7 +42,7 @@ DEBUG_HOST = '127.0.0.1'
 DEBUG_PORT = 5000
 if __name__ == '__main__':
     print(f"Starting server at {DEBUG_HOST}:{DEBUG_PORT}")
-    socketio.start_background_task(ticker.run_ticker, socketio)
+    socketio.start_background_task(ticker.run_ticker)
     socketio.run(app, use_reloader=True, debug=True, log_output=True,
                  host=DEBUG_HOST, port=DEBUG_PORT)
 

--- a/app.py
+++ b/app.py
@@ -42,7 +42,7 @@ DEBUG_HOST = '127.0.0.1'
 DEBUG_PORT = 5000
 if __name__ == '__main__':
     print(f"Starting server at {DEBUG_HOST}:{DEBUG_PORT}")
-    socketio.start_background_task(ticker.run_ticker)
+    socketio.start_background_task(ticker.run_ticker, socketio)
     socketio.run(app, use_reloader=True, debug=True, log_output=True,
                  host=DEBUG_HOST, port=DEBUG_PORT)
 

--- a/server/ticker.py
+++ b/server/ticker.py
@@ -41,7 +41,9 @@ def process_tick():
         actions[a.client_id] = a
 
     for a in actions.values():
-        entity = game_state['entities'][a.client_id]
+        entity = game_state['entities'].get(a.client_id)
+        if not entity:
+            continue
         if a.action == 'Left':
             entity[0] -= 1
         if a.action == 'Right':

--- a/server/ticker.py
+++ b/server/ticker.py
@@ -35,11 +35,12 @@ def broadcast_state(socket_server):
 
 
 def process_tick():
-    actions = []
+    actions = {}
     while not action_queue.empty():
-        actions.append(action_queue.get(block=True))
+        a = action_queue.get(block=True)
+        actions[a.client_id] = a
 
-    for a in actions:
+    for a in actions.values():
         entity = game_state['entities'][a.client_id]
         if a.action == 'Left':
             entity[0] -= 1

--- a/server/ticker.py
+++ b/server/ticker.py
@@ -1,0 +1,61 @@
+import queue
+import time
+
+TICK_INTERVAL = 1
+
+action_queue = queue.Queue()
+
+class Action:
+    client_id: str
+    action: str
+
+    def __init__(self, client_id, action):
+        self.client_id, self.action = client_id, action
+
+
+game_state = {
+    'entities': {}
+}
+
+
+def client_connect(client_id):
+    game_state['entities'][client_id] = [0, 0]
+
+
+def client_disconnect(client_id):
+    del game_state['entities'][client_id]
+
+
+def enqueue_action(client_id, action):
+    action_queue.put(Action(client_id=client_id, action=action))
+
+
+def broadcast_state(socket_server):
+    socket_server.emit('world', game_state)
+
+
+def process_tick():
+    actions = []
+    while not action_queue.empty():
+        actions.append(action_queue.get(block=True))
+
+    for a in actions:
+        entity = game_state['entities'][a.client_id]
+        if a.action == 'Left':
+            entity[0] -= 1
+        if a.action == 'Right':
+            entity[0] += 1
+        if a.action == 'Up':
+            entity[1] -= 1
+        if a.action == 'Down':
+            entity[1] += 1
+
+
+def run_ticker(socket_server):
+    tick = 0
+    while(True):
+        time.sleep(TICK_INTERVAL)
+        print("Current tick: " + str(tick))
+        process_tick()
+        broadcast_state(socket_server)
+        tick += 1


### PR DESCRIPTION
One of the first actual game element we're going to want to add is collision detection; is it legal for a player to move into a particular space?  Let's assume for a moment that we won't permit players to occupy the same space; how do we go about enforcing that rule when two players issue simultaneous requests to the server?

The simplest solution is to handle all the 'game' logic synchronously in a single gameplay update loop. There's no need currently to have a particularly high frequency of updates, so we'll have have the gameplay loop fire once per second, and then sleep off all the hard work.  

- Move `game_state` from `app.py` to new file `server/tick.py`.
- instead processing actions right away, sio event handlers simply put a client-identifiable action in a queue
- the server starts a background task that loops endlessly before starting the server
- the background task (`run_ticker`) sleeps for `TICK_INTERVAL` (1s for now), updates state, and then broadcasts the current state of things to all clients
- the state updater empties out the queue, and processes the most recent action for each client
