### PR TITLE
Respawn on death

### DIFF
--- a/client/app.ts
+++ b/client/app.ts
@@ -11,10 +11,11 @@ import { RenderContext, World, Entity, Action, ActionKind } from "./domain.js";
 import { drawRect, drawGrid } from "./draw.js"; 
 
 declare var io: any;
+declare var server: any;
 
 
 export function initialize(){
-    var socket = io("http://localhost:5000");
+    var socket = io();
     let scale = 50;
     const canvas = <HTMLCanvasElement>document.getElementById("canvas");
     const ctx = canvas.getContext("2d");
@@ -40,6 +41,9 @@ export function initialize(){
     socket.on('world', (state: World) => {
         world = state;
         update(getRenderContext(), world, scale, socket.id);
+        if(!world.entities.find(e=> e.client_id == socket.id)){
+            sendAction(socket, {"kind": "Spawn"});
+        }
     });
     // Load chat messages from the initial data (if any)
     const chatMessages: HTMLElement[] = chatData.map(msg => formatMessage(msg));
@@ -59,6 +63,7 @@ export function initialize(){
 
 
 function update(c: RenderContext, world: World, scale: number, clientId?: string) {
+    let player = world.entities.find(e=> e.client_id == clientId);
     c.ctx.clearRect(0,0, c.canvas.width, c.canvas.height);
     let cameraOffset = Vec.subtract(c.camera.position, c.camera.viewOffset);
     drawGrid(c, cameraOffset, world.width, world.height, scale);

--- a/client/domain.ts
+++ b/client/domain.ts
@@ -7,8 +7,8 @@ export type RenderContext = {
 }
 
 
-export type ActionKind = "Move" | "Attack";
-export type Action = { direction: Direction, kind: ActionKind }
+export type ActionKind = "Move" | "Attack" | "Spawn";
+export type Action = { direction?: Direction, kind: ActionKind }
 
 
 export type World = {

--- a/server/ticker.py
+++ b/server/ticker.py
@@ -106,6 +106,9 @@ def perform_action(entity: Entity, direction: str):
 
 
 def spawn_entity(client_id):
+    # despawn any existing entity for the client_id
+    despawn_entity(client_id)
+    # create an entity identified by the given client_id
     game_state.entities.append(Entity(position=Vector(0, 0),
                                       client_id=client_id))
 


### PR DESCRIPTION
Spawning is new entity is now treated as an action; the connection server handler doesn't do anything for the moment (I'll leave it there as as stub for when we want to think about authentication/persistence).

When an entity is spawned, any existing entity with the same id gets despawned (entities should be unique by socket id).

Also moved the server settings to environment variables.  Everything should continue to work as before while running locally.