### PR TITLE
Add deploy script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ help:
 	@echo "start - start the dev servers"
 	@echo "flake8 - check the python code for PEP8"
 	@echo "prettier - check with prettier and write"
+	@echo "deploy - deploy to production server with fabric, requires ssh config"
 
 clean:
 	find . -name '*.pyc' -exec rm -f {} +
@@ -21,3 +22,7 @@ flake8:
 
 prettier:
 	prettier ./**/*.{js,css,json,sass} --check
+
+
+deploy:
+	fab -H xpgame deploy

--- a/fabfile.py
+++ b/fabfile.py
@@ -1,0 +1,21 @@
+from fabric import task
+
+
+@task
+def deploy(c):
+    """
+    Deploys the project to the specified host. Expects the server to be
+    configured as follows:
+        - project repository located at ~/xp-game/
+        - a systemd service configured with the name xpgame
+        - static files to be served from /var/www/xpgame.com/
+        - a virtualenv called venv located in the project directory
+    """
+    with c.cd('~/xp-game'):
+        c.run("git pull", echo=True)
+        c.run("source venv/bin/activate && pip install -r requirements.txt",
+              echo=True)
+        c.run("tsc", echo=True)
+        c.run("sudo cp -r static/ /var/www/xpgame.com/", pty=True, echo=True)
+        c.run("sudo systemctl restart xpgame", pty=True, echo=True)
+        print("Deploy completed")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 bleach==3.1.0
 Flask-SocketIO==4.1.0
 Flask==1.1.1
+fabric==2.4.0


### PR DESCRIPTION
- Added a new dev dependency, [fabric](http://docs.fabfile.org/en/2.4/).  this enables remote execution of commands from a local script
- added a deploy script using fabric; usage `fab -H [hostname] deploy`
- added a `make` command for deploying, assuming that the host is in config as `xpgame`.

There are some server configuration requirements documented in the deploy command, but if those are met the command should work for anyone who wants to host a server.