### PR TITLE
Fix 29 server stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 /static/dist/
 /xp-game/
 
+# ignore the logs, except for the .keep file
+logs/*
+!logs/.keep
+
 # Editors
 *~
 tags

--- a/logs/.keep
+++ b/logs/.keep
@@ -1,0 +1,1 @@
+Note: this directory stores server-generated logs, but it is not stored in Git, except for this one file.

--- a/server/logger.py
+++ b/server/logger.py
@@ -4,8 +4,7 @@ from os import path
 from logging.handlers import RotatingFileHandler
 
 LOG_DIRECTORY = './logs'
-# MAX_LOG_FILESIZE = 100000000  # 100000000 bytes = 100 MB
-MAX_LOG_FILESIZE = 100  # a small number, for debug only
+MAX_LOG_FILESIZE = 100000000  # 100000000 bytes = 10 MB
 
 
 def create_logger(logger_name, fname='game.log'):
@@ -41,14 +40,15 @@ def create_logger(logger_name, fname='game.log'):
     logging.Logger.game_event = game_event
 
     logfile = path.join(LOG_DIRECTORY, fname)
-    print(f'initializing logger: {logfile}')
+    print(f'setting logfile to {logfile}')
 
-    logger = logging.getLogger(logfile)
+    logger = logging.getLogger(logger_name)
+    # GAME_EVENT level is above warning
     logger.setLevel(logging.WARNING)
 
     # add a rotating handler
-    handler = RotatingFileHandler(path,
+    handler = RotatingFileHandler(logfile,
                                   maxBytes=MAX_LOG_FILESIZE,
                                   backupCount=5)
     logger.addHandler(handler)
-    return logging.getLogger(logger_name)
+    return logger

--- a/server/logger.py
+++ b/server/logger.py
@@ -1,0 +1,54 @@
+"""This module contains a rotating logger for game events."""
+import logging
+from os import path
+from logging.handlers import RotatingFileHandler
+
+LOG_DIRECTORY = './logs'
+# MAX_LOG_FILESIZE = 100000000  # 100000000 bytes = 100 MB
+MAX_LOG_FILESIZE = 100  # a small number, for debug only
+
+
+def create_logger(logger_name, fname='game.log'):
+    """Create a logger.
+
+    In any file, run this function to create a logger.
+
+    The loglevel for game events is `game_event`.
+
+    Regarding levels:
+
+        DEBUG is 10, INFO is 20, WARNING is 30. GAME_EVENT is set to 35,
+        because it should log game events even when warnings are turned
+        off.
+
+    Find out more about that here:
+    https://docs.python.org/3/library/logging.html#logging-levels
+
+    Example usage:
+
+    ```
+    log = create_logger(__name__)
+    log.game_event('saluton mondo')
+    ```
+    """
+    logging.GAME_EVENT_LEVEL_NUM = 35
+    logging.addLevelName(logging.GAME_EVENT_LEVEL_NUM,
+                         'GAME_EVENT')
+
+    def game_event(self, message, *args, **kwargs):
+        self._log(logging.GAME_EVENT_LEVEL_NUM, message, args, **kwargs)
+
+    logging.Logger.game_event = game_event
+
+    logfile = path.join(LOG_DIRECTORY, fname)
+    print(f'initializing logger: {logfile}')
+
+    logger = logging.getLogger(logfile)
+    logger.setLevel(logging.WARNING)
+
+    # add a rotating handler
+    handler = RotatingFileHandler(path,
+                                  maxBytes=MAX_LOG_FILESIZE,
+                                  backupCount=5)
+    logger.addHandler(handler)
+    return logging.getLogger(logger_name)


### PR DESCRIPTION
This is not a great logger yet, but it records basic game events. The format needs improvement (JSON?), and it could benefit from timestamps, but it at least logs events for now. It should rotate the logs when they reach 10 MB (configurable) and keep a few backups.

`game_event` is a custom log level that is higher than `warning`, so warnings can be on or off and it will still log the game events.

```python
from server.logger import create_logger

log = create_logger(__name__)
log.game_event('a log message')  # or log.info() or whatever level you want.
```