### PR TITLE
Add a logic grid and rough in map generation

### DIFF
--- a/client/domain.ts
+++ b/client/domain.ts
@@ -26,10 +26,16 @@ export type World = {
     width: number;
     height: number;
     entities: Entity[];
+    tile_grid: Tile[][]
 }
 
 export type Entity = {
     position: Vector;
     client_id: string;
     current_action?: Action;
+}
+
+
+export type Tile = {
+    tile_id: string
 }

--- a/client/draw.ts
+++ b/client/draw.ts
@@ -50,6 +50,10 @@ export function drawTile(c: RenderContext, position: Vector, tileId: string){
             default:
             case "ground":
                 return 0;
+            case "grass":
+                return 6;
+            case "tree":
+                return 36;
             case "hero":
                 return 27;
 

--- a/client/vectors.ts
+++ b/client/vectors.ts
@@ -2,7 +2,9 @@ export type Vector = { x: number, y: number }
 export type Direction = "North" | "South" | "East" | "West";
 type V2 = Vector;
 
-export function vector(x: number, y: number): Vector { return {x: x, y: y } }
+export function vector(x: number, y: number): Vector {
+    return {x: Math.round(x), y: Math.round(y) };
+}
 export function equals(a: V2, b: V2): boolean { return a.x == b.x && a.y == b.y; }
 export function add(a: V2, b: V2): V2 {
     return {

--- a/server/environment.py
+++ b/server/environment.py
@@ -1,0 +1,29 @@
+import random
+import math
+from .world import Tile
+
+def generate_random_map(width, height):
+    random.seed(9001)
+    def get_noise(width, height):
+        noise = [[r for r in range(width)] for i in range(height)]
+
+        for i in range(height):
+            for j in range(width):
+                noise[i][j] = random.randint(0,5)
+
+        return noise
+
+    noise = get_noise(width,height)
+
+    grid = [[e for e in range(width)] for i in range(height)]
+    for y in range(height):
+        for x in range(width):
+            value = noise[y][x]
+            if value == 0:
+                grid[y][x] = Tile(tile_id="tree", is_dense=True)
+            elif value < 3:
+                grid[y][x] = Tile(tile_id="grass", is_dense=False)
+            else:
+                grid[y][x] = Tile(tile_id="ground", is_dense=False)
+                
+    return grid

--- a/server/ticker.py
+++ b/server/ticker.py
@@ -4,12 +4,13 @@ from collections import defaultdict
 from typing import Callable
 from .domain import Entity, Action, Vector, to_dict
 from .world import World, LogicGrid, Tile
+from .environment import generate_random_map
 from . import vectors as vec
 
 
 TICK_INTERVAL = 1
-WORLD_WIDTH = 5
-WORLD_HEIGHT = 5
+WORLD_WIDTH = 10
+WORLD_HEIGHT = 10 
 
 action_queue = queue.Queue()
 
@@ -17,11 +18,7 @@ game_state = World(
     width=WORLD_WIDTH,
     height=WORLD_HEIGHT,
     entities=[],
-    tile_grid=[
-        [
-            Tile(tile_id="ground", is_dense=False),
-        ] * WORLD_WIDTH
-    ]*WORLD_HEIGHT
+    tile_grid=generate_random_map(WORLD_WIDTH, WORLD_HEIGHT)
 )
 
 

--- a/server/ticker.py
+++ b/server/ticker.py
@@ -20,11 +20,7 @@ game_state = World(
     tile_grid=[
         [
             Tile(tile_id="ground", is_dense=False),
-            Tile(tile_id="ground", is_dense=False),
-            Tile(tile_id="ground", is_dense=False),
-            Tile(tile_id="ground", is_dense=False),
-            Tile(tile_id="wall", is_dense=True)
-        ]
+        ] * WORLD_WIDTH
     ]*WORLD_HEIGHT
 )
 

--- a/server/world.py
+++ b/server/world.py
@@ -1,6 +1,13 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List, Optional
 from .domain import Entity, Vector
+
+
+@dataclass
+class Tile:
+    """The environment at a given Tile; ground, walls. """
+    tile_id: str
+    is_dense: bool
 
 
 @dataclass
@@ -8,32 +15,79 @@ class World:
     width: int
     height: int
     entities: List[Entity]
+    tile_grid: List[List[Tile]]
 
-    def in_bounds(self, vector: Vector):
+
+    def get_tile(self, position: Vector) -> Tile:
+        """Returns the tile for a position; position must be in bounds"""
+        return self.tile_grid[position.y][position.x]
+
+    def in_bounds(self, vector: Vector) -> bool:
         return (vector.x >= 0 and vector.x < self.height
                 and vector.y >= 0 and vector.y < self.width)
 
-    def make_grid(self) -> List[List[List[Entity]]]:
-        """
-        Derive a 2D list of the contents of each coordinate location. The outer
-        grid is the y coordinate, and the inner is the x coordinate (think rows
-        and columns)
-        """
-        grid = []
-        for y in range(self.width):
-            grid.append([])
-            for x in range(self.height):
-                grid[y].append([])
-                grid[y][x] = []
-
-        for e in self.entities:
-            grid[e.position.y][e.position.x].append(e)
-        return grid
-
     def get_entity_by_id(self, id: str) -> Optional[Entity]:
         """Get the entity by its id. This is the preferred way of retrieving
-        and entity, and can be optimized for constant-time looking as needed"""
+        and entity, and can be optimized for constant-time lookup when needed"""
         for e in self.entities:
             if e.client_id == id:
                 return e
         return None
+
+
+@dataclass
+class Location:
+    """Represents the contents of a given a position in the world"""
+    tile: Tile
+    entity: Optional[Entity]
+
+
+@dataclass
+class LogicGrid:
+    """Derived state from the world. Places entities and tiles in the same 2D
+    grid for efficient lookups.  Movement operations should be made through the 
+    logic grid via move_entity for positional tracking on the grid. If an entity's
+    position is updated outside of the logic grid, the grid should be invalidated
+    and re-derived from the world state."""
+
+    world: World
+    grid: List[List[Location]]
+
+    def get_logic_grid(world: World) -> "LogicGrid":
+        """
+        Derive a 2D grid of Locations. The outer list is
+        the y coordinate, and the inner is the x coordinate (think rows
+        and columns)
+        """
+        grid: List[List[Entity]] = []
+        for y in range(world.width):
+            grid.append([])
+            for x in range(world.height):
+                grid[y].append([])
+                grid[y][x] = Location(tile=world.get_tile(Vector(x,y)),
+                                      entity=None)
+
+        for e in world.entities:
+            grid[e.position.y][e.position.x].entity = e
+        return LogicGrid(grid=grid, world=world)
+
+    def is_passable(self, position: Vector):
+        location = self.get_location(position)
+        return (self.world.in_bounds(position)
+                and not location.tile.is_dense
+                and not location.entity)
+
+    def get_location(self, position: Location):
+        return self.grid[position.y][position.x]
+
+    def move_entity(self, entity: Entity, destination: Vector) -> bool:
+        """Movements through the course of a tick need to be handled through move_entity
+        in order to keep the internal state of the logic grid consistent."""
+        origin_loc = self.get_location(entity.position)
+        dest_loc = self.get_location(destination)
+        if self.is_passable(destination):
+            origin_loc.entity = None
+            dest_loc.entity = entity 
+            entity.position = destination
+            return True
+        return False

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,7 +17,7 @@
     <body>
         <noscript>Please enable JavaScript to play this game.</noscript>
 
-        <canvas id="canvas" width="480" height="320"></canvas>
+        <canvas id="canvas" width="450" height="450"></canvas>
 
         <!-- Chat could be moved into canvas later, if needed. -->
         <div id="chat">


### PR DESCRIPTION
This PR introduces a `LogicGrid` to handle both environmental collision detection and collision detection for entities.

In order to determine if a tile is legal to move on to, we want to know a) if the tile is legal to move into and b) if there is already an entity at that location.  Tiles are easy to maintain as a 2d grid, as we expect them to remain more or less static. Entities move around, though; not only do we want to look them up by position, but we also want to iterate them and do lookups by their ids.

`LogicGrid` tries to resolve the lookups by position while maintaining the position on the entity itself as the single source of truth.  It gets built from the `World` state on each tick, (which contains the list of entities and grid of tiles), and is a shared 2d array with tiles at a common `Location`.  Entity movement gets handled through the logic grid (and temporarily tracked in two places) so that it doesn't need to be rebuilt every time an entity moves.

In addition to an `Entity`, a `Location` also points to a `Tile`, which contains movement and rendering related data. The client now renders tiles based on this data.

For good measure, I also threw in a quick random map generation script.