### PR TITLE
Rough out Abilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ tags.*
 *.py[cod]
 __pycache__/
 .venv/
+.mypy_cache/
 
 # Node
 node_modules/

--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ from server.logger import create_logger
 import server.ticker as ticker
 from server.domain import ClientEvent
 from server.utils import from_dict
+from server.actions import allowed_actions
 
 
 log = create_logger(__name__)
@@ -32,7 +33,7 @@ def handle_connect():
     # Authentication can go here
     log.game_event(f'client_connected: {request.sid}')
 
-    
+
 @socketio.on('disconnect')
 def handle_disconnect():
     log.game_event(f'client_disconnected: {request.sid}')
@@ -55,7 +56,6 @@ def handle_event(event_dict):
 
 @socketio.on('action')
 def handle_action(action):
-    allowed_actions = {'Attack', 'Move'}
     if action['kind'] in allowed_actions:
         log.game_event(f'action: {action} by {request.sid}')
         ticker.enqueue_action(action, request.sid)

--- a/client/domain.ts
+++ b/client/domain.ts
@@ -16,26 +16,34 @@ export type RenderContext = {
     tileset: Tileset;
 }
 
+export type ActionKind = "Move" | "Attack" | "Spawn" | "Dash" | "Aimed Shot"; 
 
-export type ActionKind = "Move" | "Attack" | "Spawn";
-export type Action = { direction?: Direction, kind: ActionKind }
+export type Action = {
+    entity?: Entity;
+    kind: ActionKind;
+    direction?: Direction;
+}
+
+export type Ability = {
+    color: string;
+    reach: number; 
+}
 
 
 export type World = {
     width: number;
     height: number;
     entities: Entity[];
-    tile_grid: Tile[][]
+    tile_grid: Tile[][];
 }
 
 export type Entity = {
     position: Vector;
     client_id: string;
-    current_action?: Action;
     health: number;
+    currentAction?: { action: Action, ability: Ability };
 }
 
-
 export type Tile = {
-    tile_id: string
+    tile_id: string;
 }

--- a/client/inputs.ts
+++ b/client/inputs.ts
@@ -3,22 +3,36 @@
  */
 import { Action, ActionKind } from "./domain.js";
 
-let ATK_PRESSED = false;
+let KeyBindings = new Map<string, ActionKind>([
+    ["a", "Attack"],
+    ["q", "Dash"],
+    ["w", "Aimed Shot"]
+]);
 
-export function handleKeyPress(event: KeyboardEvent){
-    switch (event.key){
-        case "a":
-        case "A":
-            ATK_PRESSED = true;
-            break;
-    }
+export function initializeInputListeners(keyDownCallback: (arg: Action) => void) {
+    let secondaryInput: { key: ActionKind | undefined  } = { key: undefined };
+    document.addEventListener("keydown", (e) => {
+        let input = handleKeyDown(e, secondaryInput);
+        if(input){
+            keyDownCallback(input);
+        }
+    }, false);
+    document.addEventListener("keypress", (e) => {
+        secondaryInput.key = handleKeyPress(e);
+    }, false);
+    document.addEventListener("keyup", handleKeyUp);
 }
 
-export function handleKeyDown(event: KeyboardEvent): Action | undefined {
-    // if the attack button has been pressed, set the action to Attack
-    // and clear the ATK_PRESSED input state
-    let action: ActionKind = ATK_PRESSED ? "Attack" : "Move";
-    ATK_PRESSED = false;
+
+
+function handleKeyPress(event: KeyboardEvent): ActionKind | undefined {
+    return KeyBindings.get(event.key);
+}
+
+function handleKeyDown(event: KeyboardEvent, secondaryInput?: { key: ActionKind }): Action | undefined {
+    // if a secondary input is set, perform that action and then clear the secondary input state
+    let action: ActionKind = secondaryInput.key || "Move";
+    secondaryInput.key = undefined;
 
     switch (event.key) {
         case "ArrowLeft":
@@ -37,7 +51,7 @@ export function handleKeyDown(event: KeyboardEvent): Action | undefined {
     return undefined;
 }
 
-export function handleKeyUp(event: KeyboardEvent): void {
+function handleKeyUp(event: KeyboardEvent): void {
     switch (event.key) {
         case "Enter":
             event.preventDefault();

--- a/client/vectors.ts
+++ b/client/vectors.ts
@@ -18,6 +18,7 @@ export function subtract(a: V2, b: V2): V2 {
         y: a.y - b.y
     }
 }
+export function multiply(a: V2, scalar: number) { return vector(a.x*scalar, a.y*scalar); }
 export function zero(): V2 { return vector(0, 0); }
 export function up(){ return vector(0, -1); }
 export function down(){ return vector(0, 1); }

--- a/server/actions.py
+++ b/server/actions.py
@@ -71,10 +71,10 @@ def perform_dash(action: Action, ctx: Context) -> None:
     step_dir = vec.dir_to_vec(direction)
     if not step_dir:
         return None
-    destination = vec.raycast(entity.position, step_dir, max_dist=2,
-                              predicate=ctx.logic_grid.is_passable)
-    if destination:
-        ctx.logic_grid.move_entity(entity, destination[-1])
+    _, path = vec.raycast(entity.position, step_dir, max_dist=2,
+                          predicate=ctx.logic_grid.is_passable)
+    if path:
+        ctx.logic_grid.move_entity(entity, path[-1])
 
 
 def perform_aimed_shot(action: Action, ctx: Context) -> None:
@@ -82,9 +82,10 @@ def perform_aimed_shot(action: Action, ctx: Context) -> None:
     step = vec.dir_to_vec(direction)
     if not step:
         return None
-    target_pos = vec.raycast(entity.position, step, max_dist=3,
-                             predicate=ctx.logic_grid.is_passable)
-    loc = ctx.logic_grid.get_location(target_pos[-1]) if target_pos else None
+    hit, path = vec.raycast(entity.position, step, max_dist=3,
+                            predicate=ctx.logic_grid.is_passable)
+    loc = (ctx.logic_grid.get_location(hit)
+           if hit and ctx.logic_grid.world.in_bounds(hit) else None)
     if loc and loc.entity:
         target = loc.entity
         result = (f"They strike {ctx.user_data.get(target.client_id)}, "

--- a/server/actions.py
+++ b/server/actions.py
@@ -1,0 +1,101 @@
+from dataclasses import dataclass
+from typing import Dict
+from .domain import Ability, Action
+from .world import LogicGrid
+from . import vectors as vec
+
+
+@dataclass(frozen=True)
+class Context:
+    logic_grid: LogicGrid
+    user_data: Dict[str, str]
+    socket: any
+
+
+allowed_actions = {'Attack', 'Move', 'Dash', 'Aimed Shot'}
+abilities: Dict[str, Ability] = {
+    'Attack': Ability(kind="Attack", color="red",
+                      reach=1, damage=1),
+    'Aimed Shot': Ability(kind="Aimed Shot", color="red",
+                          reach=3, damage=1),
+    'Move':   Ability(kind="Move", color="blue", reach=1),
+    'Dash':   Ability(kind="Dash", color="blue", reach=2),
+}
+
+
+def perform_ability(action: Action, ctx: Context) -> None:
+    if action.kind == "Move":
+        return perform_move(action, ctx)
+    if action.kind == "Attack":
+        return perform_attack(action, ctx)
+    if action.kind == "Dash":
+        return perform_dash(action, ctx)
+    if action.kind == "Aimed Shot":
+        return perform_aimed_shot(action, ctx)
+
+
+def perform_move(action: Action, ctx: Context) -> None:
+    entity, direction = action.entity, action.direction
+    step = vec.dir_to_vec(direction)
+    destination = vec.add(step, entity.position) if step else None
+    if destination and ctx.logic_grid.is_passable(destination):
+        ctx.logic_grid.move_entity(entity, destination)
+
+
+def perform_attack(action: Action, ctx: Context) -> None:
+    entity, direction = action.entity, action.direction
+    step = vec.dir_to_vec(direction)
+    target_pos = vec.add(step, entity.position) if step else None
+
+    loc = (ctx.logic_grid.get_location(target_pos)
+           if ctx.logic_grid.world.in_bounds(target_pos) else None)
+
+    if loc and loc.entity:
+        target = loc.entity
+        result = (f"They strike {ctx.user_data.get(target.client_id)}, "
+                  "dealing 1 damage.")
+        target.health -= 1
+    else:
+        result = "They miss."
+
+    event = {
+        'id': "",
+        'body': f"""{ctx.user_data.get(entity.client_id)} swings their """
+                f"""vorpal sword to the {direction}. {result}"""
+    }
+    ctx.socket.emit('chat', event)
+
+
+def perform_dash(action: Action, ctx: Context) -> None:
+    entity, direction = action.entity, action.direction
+    step_dir = vec.dir_to_vec(direction)
+    if not step_dir:
+        return None
+    destination = vec.raycast(entity.position, step_dir, max_dist=2,
+                              predicate=ctx.logic_grid.is_passable)
+    if destination:
+        ctx.logic_grid.move_entity(entity, destination[-1])
+
+
+def perform_aimed_shot(action: Action, ctx: Context) -> None:
+    entity, direction = action.entity, action.direction
+    step = vec.dir_to_vec(direction)
+    if not step:
+        return None
+    target_pos = vec.raycast(entity.position, step, max_dist=3,
+                             predicate=ctx.logic_grid.is_passable)
+    loc = ctx.logic_grid.get_location(target_pos[-1]) if target_pos else None
+    if loc and loc.entity:
+        target = loc.entity
+        result = (f"They strike {ctx.user_data.get(target.client_id)}, "
+                  "dealing 1 damage.")
+        target.health -= 1
+    else:
+        result = "They miss."
+
+    event = {
+        'id': "",
+        'body': f"""{ctx.user_data.get(entity.client_id)} draws their """
+                f"""bow, aiming to the {direction}. {result}"""
+    }
+    ctx.socket.emit('chat', event)

--- a/server/domain.py
+++ b/server/domain.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Optional
 from dataclasses import dataclass
 
 
@@ -21,9 +21,17 @@ class Entity:
 @dataclass(frozen=True)
 class Action:
     """An action in the game world undertaken by a specific entity"""
-    client_id: str
-    kind: str  # Move | Attack | Spawn | Despawn
-    direction: str  # North | South | East | West
+    entity: Entity
+    kind: str  # Move | Attack | Spawn | Despawn | Dash
+    direction: Optional[str]  # North | South | East | West
+
+
+@dataclass(frozen=True)
+class Ability:
+    kind: str  # Move | Attack | Dash
+    color: str
+    reach: int
+    damage: Optional[int] = None
 
 
 @dataclass(frozen=True)

--- a/server/vectors.py
+++ b/server/vectors.py
@@ -1,5 +1,5 @@
 from itertools import takewhile
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, Tuple
 from .domain import Vector
 
 
@@ -32,11 +32,20 @@ def raycast(start: Vector,
             direction: Vector,
             max_dist: int = 10,
             predicate: Callable[[Vector], bool] = lambda x: True
-            ) -> List[Vector]:
+            ) -> Tuple[Optional[Vector], List[Vector]]:
     """
     Cast a ray starting from position `start` in Vector `direction`.
-    Return a list of positions (Vectors) to a max distance of `maxDist`
-    or until `predicate` is satisfied
+    Return a tuple (hit, positions) where `hit` is the first Vector position
+    that fails the `predicate`, and positions is a list of positions (Vectors)
+    to a max distance of `maxDist` that pass the predicate
     """
-    return list(takewhile(predicate, [add(start, multiply(direction, i + 1))
-                                      for i in range(max_dist)]))
+    ray = (add(start, multiply(direction, i + 1)) for i in range(max_dist))
+    hit = None
+    ray_path = []
+    for e in ray:
+        if predicate(e):
+            ray_path.append(e)
+        else:
+            hit = e
+            break
+    return (hit, ray_path)

--- a/server/vectors.py
+++ b/server/vectors.py
@@ -1,7 +1,9 @@
+from itertools import takewhile
+from typing import Callable, List, Optional
 from .domain import Vector
 
 
-def dir_to_vec(direction: str):
+def dir_to_vec(direction: str) -> Optional[Vector]:
     """Convert a cardinal direction to a vector"""
     dir_vec_map = {
         # TODO - handle flipping the orientation to "Screen Space" on the
@@ -20,3 +22,21 @@ def add(a: Vector, b: Vector) -> Vector:
 
 def subtract(a: Vector, b: Vector) -> Vector:
     return Vector(a.x - b.x, a.y - a.y)
+
+
+def multiply(a: Vector, scalar: int):
+    return Vector(a.x * scalar, a.y * scalar)
+
+
+def raycast(start: Vector,
+            direction: Vector,
+            max_dist: int = 10,
+            predicate: Callable[[Vector], bool] = lambda x: True
+            ) -> List[Vector]:
+    """
+    Cast a ray starting from position `start` in Vector `direction`.
+    Return a list of positions (Vectors) to a max distance of `maxDist`
+    or until `predicate` is satisfied
+    """
+    return list(takewhile(predicate, [add(start, multiply(direction, i + 1))
+                                      for i in range(max_dist)]))

--- a/static/styles/main.css
+++ b/static/styles/main.css
@@ -1,5 +1,13 @@
 * { padding: 0; margin: 0; }
 
+th.controls {
+    text-align: left;
+}
+
+th.wide {
+    width: 50%;
+}
+
 .layout {
     display: grid;
     grid-template-columns: 475px 300px;

--- a/templates/index.html
+++ b/templates/index.html
@@ -68,7 +68,7 @@
                         <td>W + Arrow Key</td>
                     </tr>
                 </table>
-          </div>
-      </div>
+            </div>
+        </div>
     </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -44,11 +44,30 @@
                     <li class="equipment-item">Vorpal Sword</li>
                 </ul>
 
-            <!-- User Commands -->
-            <br>
-              <p><b>Controls</b></p>
-              <p>Move: Arrow Keys</p>
-              <p>Attack: a + direction</p>
+                <!-- User Commands -->
+                <br>
+                <table>
+                    <tr>
+                        <th class="controls wide">Ability</th>
+                        <th class="controls">Control</th>
+                    </tr>
+                    <tr>
+                        <td>Move</td>
+                        <td>Arrow Keys</td>
+                    </tr>
+                    <tr>
+                        <td>Dash</td>
+                        <td>Q + Arrow Key</td>
+                    </tr>
+                    <tr>
+                        <td>Slash</td>
+                        <td>A + Arrow Key</td>
+                    </tr>
+                    <tr>
+                        <td>Aimed Shot</td>
+                        <td>W + Arrow Key</td>
+                    </tr>
+                </table>
           </div>
       </div>
     </body>


### PR DESCRIPTION
This is intended as an incremental step moving towards defining abilities as data, and separating the behavior.  There is a new `Ability` data type on the server that is used to define the range, damage, and telegraph for abilities.  
The calls to particular ability functions (`perform_attack`, `perform_move`, etc) is no longer handled in `tickers.py`, and a `perform_ability` function is called and chooses which function in `actions.py` to call.  A next step here would be to remove the specific ability function calls, and make it more fully data-- this will move us closer to an easily customizable and extendable ability system.

- Added a `Dash` ability that lets you move two tiles
- Added an `Aimed Shot` ability that lets you shoot up to 3 tiles away
- added `vectors.raycast` function for determining the first collision in a direction emanating from a starting position 
- refactored the `input` module for easy support to adding new directional abilities
- updated the controls info
