### PR TITLE
Simplify websocket message formats

### DIFF
--- a/client/app.ts
+++ b/client/app.ts
@@ -1,6 +1,6 @@
 import { vector, Vector } from "./common/vectors.js";
 import * as Vec from "./common/vectors.js";
-import { sendAction, requestLogin } from "./common/server.js";
+import { sendMessage } from "./common/server.js";
 import { RenderContext, World, Ability, Action } from "./common/domain.js";
 import { chatData, initializeChatListener } from "./player/chat.js";
 import { printMessage, EventType } from './player/eventBox.js';
@@ -17,7 +17,7 @@ async function initialize(){
     const tileset = await getTileset();
     var socket = io('/');
     let [subscribeInputListeners,
-         unsubscribeInputListeners] = initializeInputListeners((input) => sendAction(socket, input));
+         unsubscribeInputListeners] = initializeInputListeners((input) => sendMessage(socket, "action", input));
 
     function respawn(){
         // disable input events
@@ -25,13 +25,16 @@ async function initialize(){
         handleLogin(name => {
             setUsername(name);
             setHealth(0);
-            requestLogin(socket, name);
+            sendMessage(socket, "spawn", { character_name: name });
             setTimeout(() => {
                 subscribeInputListeners();
             }, 500);
         });
     }
 
+    /* when the client receives a message on either the connect
+    or the despawn channels, they respawn immediately
+    */
     socket.on('connect', () => respawn());
     socket.on('despawn', () => respawn());
 

--- a/client/common/domain.ts
+++ b/client/common/domain.ts
@@ -1,5 +1,6 @@
 import { Vector, Direction } from "./vectors";
 
+
 export interface Tileset {
     tileWidth: number;
     tileHeight: number;
@@ -15,6 +16,7 @@ export type RenderContext = {
     scale: number;
     tileset: Tileset;
 }
+
 
 export type ActionKind = "Move" | "Attack" | "Spawn" | "Dash" | "Aimed Shot";
 

--- a/client/common/server.ts
+++ b/client/common/server.ts
@@ -1,20 +1,16 @@
 import { Action } from "./domain.js";
 
+type EventType = "spawn" | "action" | "chat";
+
 type ClientEvent = {
-    kind: "login" 
-    detail:  {character_name: string}
+    event_type: EventType
+    data:  {character_name: string} | Action
 }
 
-export function sendAction(socket: any, action: Action){
-    socket.emit('action', action);
-}
-
-export function requestLogin(socket: any, username: string){
-    let event: ClientEvent ={
-        kind: "login",
-        detail: {
-            character_name: username
-        }
+export function sendMessage(socket: any, eventType: EventType, message: Action | { character_name: string }){
+    let event: ClientEvent = {
+        event_type: eventType,
+        data: message
     };
     socket.emit('event', event);
 }

--- a/server/utilities/logger.py
+++ b/server/utilities/logger.py
@@ -52,3 +52,7 @@ def create_logger(logger_name, fname='game.log'):
                                   backupCount=5)
     logger.addHandler(handler)
     return logger
+
+
+log = create_logger(__name__)
+log.game_event('created logger')

--- a/server/utilities/serialize.py
+++ b/server/utilities/serialize.py
@@ -21,3 +21,4 @@ def from_dict(data: Dict, to_type):
     except Exception:
         log.exception("Unable to parse client event")
     return None
+    


### PR DESCRIPTION
One of my current goals is to make it possible to do more gameplay/backend programming independently of the client. My thought on how to accomplish this is to make xp-game somewhat '[mudlike](https://en.wikipedia.org/wiki/MUD)'.  Essentially I'd like to be able to build functionality entirely on the backend, and make it playable entirely through the chat interface. Contributors more interested in doing frontend development will likewise be able to take features implemented through the text interface and put together graphical interactions for them.

Currently wip is figuring out a flexible message passing format to support that. This PR consolidates the `event` and `action` websocket channels; I'd like to have that also subsume the `chat` channel.  

The goal for the PR will ultimately be to make all the currently gameplay playable through the chatline (movement, attacking, dashing, shooting arrows).

 